### PR TITLE
action added: react-native-build

### DIFF
--- a/.github/workflows/react-native-build.yml
+++ b/.github/workflows/react-native-build.yml
@@ -1,0 +1,31 @@
+name: Build
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    
+jobs:
+  install-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.3
+      - name: Install npm dependencies
+        run: |
+          npm install
+  build-android:
+    needs: install-and-test
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v2.3.3
+      - name: Install npm dependencies
+        run: |
+          npm install
+      - name: Build Android Release
+        run: |
+          cd android && ./gradlew assembleRelease
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2.2.0
+        with:
+          name: app-release.apk
+          path: android/app/build/outputs/apk/release/


### PR DESCRIPTION
# Description
Github Actions added for React-Native builds. The action will trigger on pull and push request into main branch and currently performs two jobs - "install-and-test" and "build-android". The workflow after completion builds the apk and stores it in: 
#### android/app/build/outputs/apk/release/app-released.apk)

Fixes #14

# Type of Change:

- Code



# How Has This Been Tested?
Tested it on my local repo


# Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented on my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

